### PR TITLE
Enable calc_derived to work with vectorized 3-compartment model parameters

### DIFF
--- a/R/calc_derived.R
+++ b/R/calc_derived.R
@@ -21,7 +21,7 @@
 #'   \item \code{k21}: First-order rate of transfer from first peripheral to central compartment, \eqn{k_{21}} (/h); 2- and 3-compartment
 #'   \item \code{k13}: First-order rate of transfer from central to second peripheral compartment, \eqn{k_{13}} (/h); 3-compartment
 #'   \item \code{k31}: First-order rate of transfer from second peripheral to central compartment,\eqn{k_{31}} (/h); 3-compartment
-#'   \item \code{thalf_alpha}: \eqn{t_{1/2,\alpha}} (h); 2- and 3-compartment
+#'   \item \code{thalf_alpha}: \eqn{t_{1/2,\alpha}} (h); 1-, 2-, and 3-compartment
 #'   \item \code{thalf_beta}: \eqn{t_{1/2,\beta}} (h); 2- and 3-compartment
 #'   \item \code{thalf_gamma}: \eqn{t_{1/2,\gamma}} (h); 3-compartment
 #'   \item \code{alpha}: \eqn{\alpha}; 1-, 2-, and 3-compartment
@@ -37,7 +37,8 @@
 #'
 #' The input parameters with standardized names (`V1`, `V2`, `V3`, `CL`, `Q2`,
 #' and `Q3`) are also returned in the list, and if provided, additional PK
-#' parameters of `ka` and `lag` are also returned in the list.
+#' parameters of `ka` and `lag` are also returned in the list.  All inputs may
+#' be scalars or vectors.
 #'
 #' @author Justin Wilkins, \email{justin.wilkins@@occams.com}
 #' @references Shafer S. L. \code{CONVERT.XLS}
@@ -213,9 +214,10 @@ calc_derived_3cpt <- function(CL, V1=NULL, V2, V3, Q2=NULL, Q3, V=NULL, Q=NULL, 
   root2 <- -(cos(phi + 2 * pi/3) * r2 - a2/3)
   root3 <- -(cos(phi + 4 * pi/3) * r2 - a2/3)
   
-  i1 <- max(c(root1, root2, root3))
-  i2 <- median(c(root1, root2, root3))
-  i3 <- min(c(root1, root2, root3))
+  i1 <- pmax(root1, root2, root3)
+  # There is no pmedian function
+  i2 <- mapply(FUN=function(...) median(c(...)), root1, root2, root3)
+  i3 <- pmin(root1, root2, root3)
   
   c1 <- (k21 - i1) * (k31 - i1) / (i1 - i2) / (i1 - i3) / V1
   c2 <- (k21 - i2) * (k31 - i2) / (i2 - i1) / (i2 - i3) / V1

--- a/man/calc_derived.Rd
+++ b/man/calc_derived.Rd
@@ -81,7 +81,7 @@ Return a list of derived PK parameters for a 1-, 2-, or 3-compartment linear mod
   \item \code{k21}: First-order rate of transfer from first peripheral to central compartment, \eqn{k_{21}} (/h); 2- and 3-compartment
   \item \code{k13}: First-order rate of transfer from central to second peripheral compartment, \eqn{k_{13}} (/h); 3-compartment
   \item \code{k31}: First-order rate of transfer from second peripheral to central compartment,\eqn{k_{31}} (/h); 3-compartment
-  \item \code{thalf_alpha}: \eqn{t_{1/2,\alpha}} (h); 2- and 3-compartment
+  \item \code{thalf_alpha}: \eqn{t_{1/2,\alpha}} (h); 1-, 2-, and 3-compartment
   \item \code{thalf_beta}: \eqn{t_{1/2,\beta}} (h); 2- and 3-compartment
   \item \code{thalf_gamma}: \eqn{t_{1/2,\gamma}} (h); 3-compartment
   \item \code{alpha}: \eqn{\alpha}; 1-, 2-, and 3-compartment
@@ -97,7 +97,8 @@ Return a list of derived PK parameters for a 1-, 2-, or 3-compartment linear mod
 
 The input parameters with standardized names (`V1`, `V2`, `V3`, `CL`, `Q2`,
 and `Q3`) are also returned in the list, and if provided, additional PK
-parameters of `ka` and `lag` are also returned in the list.
+parameters of `ka` and `lag` are also returned in the list.  All inputs may
+be scalars or vectors.
 }
 \description{
 Calculate derived pharmacokinetic parameters for a 1-, 2-, or 3-compartment linear model.

--- a/tests/testthat/test-calc.R
+++ b/tests/testthat/test-calc.R
@@ -190,6 +190,3 @@ test_that("3-compartment linear, first-order oral with lag time, steady-state", 
   t <- calc_ss_3cmt_linear_oral_1_lag(t=seq(0, 24, by=3), CL = 87.6, V1 = 20.1, V2 = 186, V3=749, Q2 = 111, Q3 = 53.4, dose = 280, ka = 1.5, tlag = 1.2, tau=12)
   expect_equal(signif(t, 4), c(0.10400, 0.41810, 0.19010, 0.13210, 0.10400, 0.08716, 0.07516, 0.06561, 0.05757))
 })
-
-
-

--- a/tests/testthat/test-convert.R
+++ b/tests/testthat/test-convert.R
@@ -10,6 +10,22 @@ test_that("1-compartment model", {
     list(k10=0.64, Vss=25, thalf=1.083, alpha=0.64, trueA=0.04, fracA=1,
          V1=25, CL=16, ka=NULL, tlag=NULL)
   )
+  t_vec <- calc_derived_1cpt(CL=c(16, 8), V=c(25, 25))
+  expect_equal(
+    t_vec,
+    list(
+      k10=c(0.64, 0.32),
+      Vss=c(25, 25),
+      thalf=c(1.083, 2.1661),
+      alpha=c(0.64, 0.32),
+      trueA=c(0.04, 0.04),
+      fracA=1,
+      V1=c(25, 25),
+      CL=c(16, 8),
+      ka=NULL,
+      tlag=NULL
+    )
+  )
 })
 
 test_that("2-compartment model", {
@@ -20,6 +36,30 @@ test_that("2-compartment model", {
       k10=0.64, k12=0.02, k21=0.01, Vss=75, thalf_alpha=1.0497, thalf_beta=71.514, alpha=0.66031, beta=0.0096925,
       trueA=0.039981, trueB=1.8908e-05, fracA=0.99953, fracB=0.0004727,
       V1=25, V2=50, CL=16, Q2=0.5, ka=NULL, tlag=NULL
+    )
+  )
+  t_vec <- calc_derived_2cpt(CL=c(16, 8), V1=c(25, 50), V2=c(50, 25), Q=c(0.5, 1))
+  expect_equal(
+    t_vec,
+    list(
+      k10=c(0.64, 0.16),
+      k12=c(0.02, 0.02),
+      k21=c(0.01, 0.04),
+      Vss=c(75, 75),
+      thalf_alpha=c(1.0497, 3.7367),
+      thalf_beta=c(71.514, 20.090),
+      alpha=c(0.66031, 0.1855),
+      beta=c(0.0096925, 0.034502),
+      trueA=c(0.039981, 0.019272),
+      trueB=c(1.8908e-05, 7.2827e-04),
+      fracA=c(0.99953, 0.96359),
+      fracB=c(0.0004727, 0.0364140),
+      V1=c(25, 50),
+      V2=c(50, 25),
+      CL=c(16, 8),
+      Q2=c(0.5, 1),
+      ka=NULL,
+      tlag=NULL
     )
   )
 })
@@ -35,6 +75,49 @@ test_that("3-compartment model", {
       trueA=0.038279, trueB=0.0043467, trueC=0.0001098,
       fracA=0.89572, fracB=0.10171, fracC=0.0025692,
       V1=23.4, V2=114, V3=4614, CL=29.4, Q2=270, Q3=73, ka=NULL, tlag=NULL
+    )
+  )
+  t_vec <-
+    calc_derived_3cpt(
+      CL=c(20, 10),
+      V1=c(20, 10),
+      V2=c(30, 40),
+      V3=c(40, 100),
+      Q2=c(10, 20),
+      Q3=c(30, 40)
+    )
+  # Compares equally to:
+  #t_vec1 <- calc_derived_3cpt(CL=20, V1=20, V2=30, V3=40, Q2=10, Q3=30)
+  #t_vec2 <- calc_derived_3cpt(CL=10, V1=10, V2=40, V3=100, Q2=20, Q3=40)
+  expect_equal(
+    t_vec,
+    list(
+      k10=c(1, 1),
+      k12=c(0.5, 2),
+      k21=c(0.33333, 0.5),
+      k13=c(1.5, 4),
+      k31=c(0.75, 0.4),
+      Vss=c(90, 150), 
+      thalf_alpha=c(0.19991, 0.093988),
+      thalf_beta=c(1.510, 1.484),
+      thalf_gamma=c(4.4129, 11.938),
+      alpha=c(3.4672, 7.3749),
+      beta=c(0.45905, 0.46709),
+      gamma=c(0.15707, 0.05806),
+      trueA=c(0.042759, 0.094872),
+      trueB=c(0.0020133, 7.8148e-05),
+      trueC=c(0.0052276, 0.0050494),
+      fracA=c(0.85518, 0.94872),
+      fracB=c(0.040266, 0.00078148),
+      fracC=c(0.10455, 0.050494),
+      V1=c(20, 10),
+      V2=c(30, 40),
+      V3=c(40, 100),
+      CL=c(20, 10),
+      Q2=c(10, 20),
+      Q3=c(30, 40),
+      ka=NULL,
+      tlag=NULL
     )
   )
 })


### PR DESCRIPTION
`calc_derived_3cpt()` returned an incorrect answer for the half-lives for vectorized inputs.  This corrects that (and it fixes a minor documentation typo).